### PR TITLE
Add DynamicMaze Playwright tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "lint": "next lint",
     "test": "playwright test",
     "test:static": "PLAYWRIGHT_PROJECT=static-land playwright test --project=static-land",
+    "test:dynamic": "PLAYWRIGHT_PROJECT=dynamic-maze playwright test --project=dynamic-maze",
     "test:report": "npx playwright show-report",
-    "test:report:static": "npx playwright show-report $(ls -td tests/static/result/*/reports/html 2>/dev/null | head -1 || echo 'tests/static/result')"
+    "test:report:static": "npx playwright show-report $(ls -td tests/static/result/*/reports/html 2>/dev/null | head -1 || echo 'tests/static/result')",
+    "test:report:dynamic": "npx playwright show-report $(ls -td tests/dynamic/result/*/reports/html 2>/dev/null | head -1 || echo 'tests/dynamic/result')"
   },
   "dependencies": {
     "next": "15.3.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,13 +37,13 @@ export default defineConfig({
       outputDir: `${getOutputDir()}artifacts/`,
       use: { ...devices['Desktop Chrome'] },
     },
+    {
+      name: 'dynamic-maze',
+      testDir: './tests/dynamic',
+      outputDir: `${getOutputDir()}artifacts/`,
+      use: { ...devices['Desktop Chrome'] },
+    },
     // Future projects for other sites:
-    // {
-    //   name: 'dynamic-maze',
-    //   testDir: './tests/dynamic',
-    //   outputDir: `./tests/dynamic/result/${timestamp}/`,
-    //   use: { ...devices['Desktop Chrome'] },
-    // },
     // {
     //   name: 'client-shadow',
     //   testDir: './tests/client-only',

--- a/tests/dynamic/README.md
+++ b/tests/dynamic/README.md
@@ -1,0 +1,19 @@
+# DynamicMaze Test Results
+
+## Overview
+This directory contains basic tests for the DynamicMaze site. Because the pages are generated with randomized layouts, the tests only verify that key pages load successfully and contain the expected headings.
+
+## Test Coverage
+- Home page `/dynamic`
+- Section page `/dynamic/sections/1`
+- Random structure page `/dynamic/random`
+
+## Running Tests
+```bash
+# Run DynamicMaze tests only
+npm run test:dynamic
+
+# Show the latest DynamicMaze test report
+npm run test:report:dynamic
+```
+

--- a/tests/dynamic/pages.spec.ts
+++ b/tests/dynamic/pages.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('DynamicMaze Pages', () => {
+  test('home page loads', async ({ page }) => {
+    await page.goto('/dynamic');
+    await expect(page.locator('h1')).toContainText('Dynamic Maze');
+  });
+
+  test('first section page exists', async ({ page }) => {
+    await page.goto('/dynamic/sections/1');
+    await expect(page.locator('h1')).toContainText('Section 1');
+  });
+
+  test('random structure page loads', async ({ page }) => {
+    await page.goto('/dynamic/random');
+    await expect(page.getByRole('heading', { name: /Random Chaos Structure/i })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add scripts to run DynamicMaze tests
- enable dynamic-maze project in Playwright config
- document DynamicMaze test basics
- add minimal Playwright tests for DynamicMaze

## Testing
- `npm run test:dynamic`
- `npm run test:static` *(fails: connection issues)*

------
https://chatgpt.com/codex/tasks/task_e_684f0757406083299b7a25c94471e17b